### PR TITLE
gh-hook-mr: use github access token for login

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
 # GitHub
-GH_LOGIN="user"
-GH_PASS="pass"
+GH_TOKEN="access_token"

--- a/gh-hook-mr.py
+++ b/gh-hook-mr.py
@@ -25,11 +25,10 @@ import os
 ghpath = Path.home() / '.env'
 load_dotenv(dotenv_path=str(ghpath))
 
-gh_login = os.getenv("GH_LOGIN")
-gh_password = os.getenv("GH_PASS")
+gh_token = os.getenv("GH_TOKEN")
 
-if not gh_login or not gh_password:
-	print("GitHub login missing!")
+if not gh_token:
+	print("GitHub token missing!")
 	sys.exit(1)
 
 qin = sys.stdin.read()
@@ -46,7 +45,7 @@ print("""<!DOCTYPE HTML>
 io = StringIO(qin)
 js = json.load(io)
 
-gh = login(gh_login, gh_password)
+gh = login(token=gh_token)
 
 action = js['action']
 if action == "synchronize" or action == "opened":


### PR DESCRIPTION
Basic GitHub authentication using a username and password is deprecated.

Signed-off-by: Matias Elo <matias.elo@nokia.com>