### PR TITLE
Dockerfile: upgrade Ubuntu version to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 ENV LISTENING_PORT=80
 
-RUN apt-get update && apt-get install -yy --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yy --no-install-recommends \
 	git \
 	nano \
 	nginx \

--- a/gh-hook-mr-dpdk.py
+++ b/gh-hook-mr-dpdk.py
@@ -13,13 +13,9 @@ import time
 import json
 from io import StringIO
 import sys, urllib
-from cgi import parse_qs, escape
 import re
 from pathlib import Path
 from github3 import login
-from github3 import pulls
-from github3 import issues
-from github3 import issue
 import os
 
 ghpath = Path.home() / '.env'

--- a/gh-hook-mr.py
+++ b/gh-hook-mr.py
@@ -13,13 +13,9 @@ import time
 import json
 from io import StringIO
 import sys, urllib
-from cgi import parse_qs, escape
 import re
 from pathlib import Path
 from github3 import login
-from github3 import pulls
-from github3 import issues
-from github3 import issue
 import os
 
 ghpath = Path.home() / '.env'


### PR DESCRIPTION
Bump Ubuntu version from 16.04 to 20.04. Unused/deprecated imports have
been removed from python scripts.

Signed-off-by: Matias Elo <matias.elo@nokia.com>